### PR TITLE
Remove dashes from specs

### DIFF
--- a/ui/narrative/methods/align_reads_using_tophat/spec.json
+++ b/ui/narrative/methods/align_reads_using_tophat/spec.json
@@ -221,7 +221,7 @@
         },
         {
           "input_parameter" : "max_intron_length",
-          "target_property" : "maxi_intron_length"
+          "target_property" : "max_intron_length"
         },
        	{
           "input_parameter" : "min_anchor_length",

--- a/ui/narrative/methods/align_reads_using_tophat/spec.json
+++ b/ui/narrative/methods/align_reads_using_tophat/spec.json
@@ -79,7 +79,7 @@
       "validate_as" : "int"
     }
   }, {
-      "id" : "min-anchor-length",
+      "id" : "min_anchor_length",
     "optional" : true,
     "advanced" : true,
     "allow_multiple" : false,
@@ -224,7 +224,7 @@
           "target_property" : "maxi_intron_length"
         },
        	{
-          "input_parameter" : "min-anchor-length",
+          "input_parameter" : "min_anchor_length",
           "target_property" : "min-anchor-length"
         },
         {
@@ -264,7 +264,7 @@
 	{
 	"constant_value": "5",
 	"target_property": "report_window_line_height"
-	} 
+	}
       ]
     }
   },


### PR DESCRIPTION
I think @sjyoo beat me to almost all of these, except for TopHat.
I also found what looks like a typo in the tophat spec.json mapping (at least, there was no `maxi_intron_length` in the main TypeSpec).