### PR TITLE
TASK-640: make RNASeq test data local

### DIFF
--- a/RELEASE_NOTES
+++ b/RELEASE_NOTES
@@ -16,7 +16,8 @@ It has the following primary scripts for the following narrative methhods:
 
 ---
 
-VERSION 0.1
+VERSION 1.0.3
 
 ---
+- Updated tests to use local data stored in the git repo
 

--- a/kbase.yml
+++ b/kbase.yml
@@ -2,7 +2,7 @@ module-name:
     KBaseRNASeq
 
 module-version:
-    1.0.2
+    1.0.3
 
 module-description:
     KBase module for the RNASeq service

--- a/lib/biokbase/RNASeq/KBaseRNASeqImpl.py
+++ b/lib/biokbase/RNASeq/KBaseRNASeqImpl.py
@@ -81,7 +81,7 @@ class KBaseRNASeq:
     VERSION = "0.0.1"
     GIT_URL = "https://github.com/kbase/KBaseRNASeq"
     GIT_COMMIT_HASH = "13e98933aea51ffac6b401451d8aebb874958614"
-    
+
     #BEGIN_CLASS_HEADER
     __TEMP_DIR = 'temp'
     __PUBLIC_SHOCK_NODE = 'true'
@@ -127,11 +127,11 @@ class KBaseRNASeq:
         #      self.__RSCRIPTS_DIR = config['rscripts_dir']
         if 'force_shock_node_2b_public' in config: # expect 'true' or 'false' string
               self.__PUBLIC_SHOCK_NODE = config['force_shock_node_2b_public']
-        self.__CALLBACK_URL = os.environ['SDK_CALLBACK_URL']	
-        
+        self.__CALLBACK_URL = os.environ['SDK_CALLBACK_URL']
+
         self.__SERVICES = { 'workspace_service_url' : self.__WS_URL,
                             'shock_service_url'     : self.__SHOCK_URL,
-                            'handle_service_url'    : self.__HS_URL, 
+                            'handle_service_url'    : self.__HS_URL,
                             'callback_url'          : self.__CALLBACK_URL }
         # logging
         self.__LOGGER = logging.getLogger('KBaseRNASeq')
@@ -150,7 +150,7 @@ class KBaseRNASeq:
 
         #END_CONSTRUCTOR
         pass
-    
+
 
     def CreateRNASeqSampleSet(self, ctx, params):
         """
@@ -180,16 +180,17 @@ class KBaseRNASeq:
         # ctx is the context object
         # return variables are: returnVal
         #BEGIN CreateRNASeqSampleSet
-	
+
 	user_token=ctx['token']
         ws_client=Workspace(url=self.__WS_URL, token=user_token)
 	hs = HandleService(url=self.__HS_URL, token=user_token)
 	try:
-            params["sample_ids"] = [ sample_id for item in params['sample_n_conditions'] for sample_id in item['sample_id']]
-            params["condition"]  = [ item['condition'] for item in params['sample_n_conditions'] for sample_id in item['sample_id']]
-            del params['sample_n_conditions']
+            # commented out these lines since these keys are not in params
+            #params["sample_ids"] = [ sample_id for item in params['sample_n_conditions'] for sample_id in item['sample_id']]
+            #params["condition"]  = [ item['condition'] for item in params['sample_n_conditions'] for sample_id in item['sample_id']]
+            #del params['sample_n_conditions']
 	    ### Create the working dir for the method; change it to a function call
-	    out_obj = { k:v for k,v in params.iteritems() if not k in ('ws_id')}  	
+	    out_obj = { k:v for k,v in params.iteritems() if not k in ('ws_id')}
 	    sample_ids = params["sample_ids"]
 	    out_obj['num_samples'] = len(sample_ids)
 	    ## Validation to check if the Set contains more than one samples
@@ -206,15 +207,15 @@ class KBaseRNASeq:
 	    	s_info = script_util.ws_get_obj_info(self.__LOGGER, ws_client, params['ws_id'], i)
                 obj_type = s_info[0][2].split('-')[0]
 		if not (obj_type in lib_type):
-			raise ValueError("Library_type mentioned : {0}. Please add only {1} typed objects in Reads fields".format(params["Library_type"],params["Library_type"])) 
-	
+			raise ValueError("Library_type mentioned : {0}. Please add only {1} typed objects in Reads fields".format(params["Library_type"],params["Library_type"]))
+
    	    ## Code to Update the Provenance; make it a function later
             provenance = [{}]
             if 'provenance' in ctx:
                 provenance = ctx['provenance']
             #add additional info to provenance here, in this case the input data object reference
             provenance[0]['input_ws_objects']=[ script_util.ws_get_ref(self.__LOGGER, ws_client,params['ws_id'],sample) for sample in sample_ids]
-	    
+
 	    #Saving RNASeqSampleSet to Workspace
 	    self.__LOGGER.info("Saving {0} object to workspace".format(params['sampleset_id']))
 	    res= ws_client.save_objects(
@@ -256,7 +257,7 @@ class KBaseRNASeq:
 	hs = HandleService(url=self.__HS_URL, token=user_token)
 	try:
 	    	if not os.path.exists(self.__SCRATCH): os.makedirs(self.__SCRATCH)
-                bowtie_dir = os.path.join(self.__SCRATCH ,'tmp') 
+                bowtie_dir = os.path.join(self.__SCRATCH ,'tmp')
 	        handler_util.setupWorkingDir(self.__LOGGER,bowtie_dir)
 		## Update the provenance
 	     	provenance = [{}]
@@ -264,7 +265,7 @@ class KBaseRNASeq:
             		provenance = ctx['provenance']
         	# add additional info to provenance here, in this case the input data object reference
         	provenance[0]['input_ws_objects']=[script_util.ws_get_ref(self.__LOGGER, ws_client, params['ws_id'],params['reference'])]
-		
+
 		try:
 			ref_id, outfile_ref_name = rnaseq_util.get_fa_from_genome(self.__LOGGER,ws_client,self.__SERVICES,params['ws_id'],bowtie_dir,params['reference'])
                 except Exception, e:
@@ -275,14 +276,14 @@ class KBaseRNASeq:
 	    		if outfile_ref_name:
 				bowtie_index_cmd = "{0} {1}".format(outfile_ref_name,params['reference'])
 			else:
-				bowtie_index_cmd = "{0} {1}".format(params['reference'],params['reference']) 
-	    	        self.__LOGGER.info("Executing: bowtie2-build {0}".format(bowtie_index_cmd))  	
+				bowtie_index_cmd = "{0} {1}".format(params['reference'],params['reference'])
+	    	        self.__LOGGER.info("Executing: bowtie2-build {0}".format(bowtie_index_cmd))
 			cmdline_output = script_util.runProgram(self.__LOGGER,"bowtie2-build",bowtie_index_cmd,None,bowtie_dir)
 			if 'result' in cmdline_output:
 				report = cmdline_output['result']
 		except Exception,e:
 			raise KBaseRNASeqException("Error while running BowtieIndex {0},{1}".format(params['reference'],e))
-		
+
 	    ## Zip the Index files
 		try:
 			script_util.zip_files(self.__LOGGER, bowtie_dir,os.path.join(self.__SCRATCH ,"%s.zip" % params['output_obj_name']))
@@ -304,7 +305,7 @@ class KBaseRNASeq:
                         except Exception, e2:
                             self.__LOGGER.exception(e2)
 			    raise KBaseRNASeqException("Failed to upload the Zipped Bowtie2Indexes file: {0}".format(e))
-	    	bowtie2index = { "handle" : bowtie_handle ,"size" : os.path.getsize(out_file_path),'genome_id' : ref_id}   
+	    	bowtie2index = { "handle" : bowtie_handle ,"size" : os.path.getsize(out_file_path),'genome_id' : ref_id}
 
 	     ## Save object to workspace
 	   	self.__LOGGER.info( "Saving bowtie indexes object to  workspace")
@@ -375,15 +376,15 @@ class KBaseRNASeq:
         # ctx is the context object
         # return variables are: returnVal
         #BEGIN Bowtie2Call
-	
+
 	if not os.path.exists(self.__SCRATCH): os.makedirs(self.__SCRATCH)
         bowtie2_dir = os.path.join(self.__SCRATCH,"tmp")
-        handler_util.setupWorkingDir(self.__LOGGER,bowtie2_dir) 
+        handler_util.setupWorkingDir(self.__LOGGER,bowtie2_dir)
         common_params = {'ws_client' : Workspace(url=self.__WS_URL, token=ctx['token']),
                          'hs_client' : HandleService(url=self.__HS_URL, token=ctx['token']),
                          'user_token' : ctx['token']
                         }
-        # Set the Number of threads if specified 
+        # Set the Number of threads if specified
 
         if 'num_threads' in params and params['num_threads'] is not None:
             common_params['num_threads'] = params['num_threads']
@@ -432,13 +433,13 @@ class KBaseRNASeq:
         #BEGIN Hisat2Call
 	if not os.path.exists(self.__SCRATCH): os.makedirs(self.__SCRATCH)
         hisat2_dir = os.path.join(self.__SCRATCH,"tmp")
-        handler_util.setupWorkingDir(self.__LOGGER,hisat2_dir) 
+        handler_util.setupWorkingDir(self.__LOGGER,hisat2_dir)
 	# Set the common Params
 	common_params = {'ws_client' : Workspace(url=self.__WS_URL, token=ctx['token']),
                          'hs_client' : HandleService(url=self.__HS_URL, token=ctx['token']),
                          'user_token' : ctx['token']
                         }
-	# Set the Number of threads if specified 
+	# Set the Number of threads if specified
 
         if 'num_threads' in params and params['num_threads'] is not None:
             common_params['num_threads'] = params['num_threads']
@@ -487,13 +488,13 @@ class KBaseRNASeq:
         #BEGIN TophatCall
 	if not os.path.exists(self.__SCRATCH): os.makedirs(self.__SCRATCH)
         tophat_dir = os.path.join(self.__SCRATCH,"tmp")
-        handler_util.setupWorkingDir(self.__LOGGER,tophat_dir) 
+        handler_util.setupWorkingDir(self.__LOGGER,tophat_dir)
 	# Set the common Params
 	common_params = {'ws_client' : Workspace(url=self.__WS_URL, token=ctx['token']),
                          'hs_client' : HandleService(url=self.__HS_URL, token=ctx['token']),
                          'user_token' : ctx['token']
                         }
-	# Set the Number of threads if specified 
+	# Set the Number of threads if specified
         if 'num_threads' in params and params['num_threads'] is not None:
             common_params['num_threads'] = params['num_threads']
 
@@ -544,13 +545,13 @@ class KBaseRNASeq:
         #BEGIN StringTieCall
 	if not os.path.exists(self.__SCRATCH): os.makedirs(self.__SCRATCH)
         stringtie_dir = os.path.join(self.__SCRATCH,"tmp")
-        handler_util.setupWorkingDir(self.__LOGGER,stringtie_dir) 
+        handler_util.setupWorkingDir(self.__LOGGER,stringtie_dir)
 	# Set the common Params
 	common_params = {'ws_client' : Workspace(url=self.__WS_URL, token=ctx['token']),
                          'hs_client' : HandleService(url=self.__HS_URL, token=ctx['token']),
                          'user_token' : ctx['token']
                         }
-	# Set the Number of threads if specified 
+	# Set the Number of threads if specified
         if 'num_threads' in params and params['num_threads'] is not None:
             common_params['num_threads'] = params['num_threads']
 
@@ -559,7 +560,7 @@ class KBaseRNASeq:
 	#obj_info = wsc.get_object_info_new({"objects": [{'name': params['alignmentset_id'], 'workspace': params['ws_id']}]})
         obj_info = script_util.ws_get_obj_info(self.__LOGGER, wsc, params['ws_id'], params['alignmentset_id'])
         obj_type = obj_info[0][2].split('-')[0]
-	if obj_type == 'KBaseRNASeq.RNASeqAlignmentSet':	
+	if obj_type == 'KBaseRNASeq.RNASeqAlignmentSet':
 		self.__LOGGER.info("StringTie AlignmentSet Case")
         	sts = StringTieSampleSet(self.__LOGGER, stringtie_dir, self.__SERVICES, self.__MAX_CORES)
         	returnVal = sts.run(common_params, params)
@@ -753,7 +754,7 @@ class KBaseRNASeq:
             # There used to be a method called
             # createExpressionMatrix, but it's now gone?
             # Not implementing this for now.
-            
+
         # save the report
         # don't do this for now, since adding a report client would
         # be a larger change than we want to merge in one step
@@ -793,7 +794,7 @@ class KBaseRNASeq:
                          'hs_client' : HandleService(url=self.__HS_URL, token=ctx['token']),
                          'user_token' : ctx['token']
                         }
-        # Set the Number of threads if specified 
+        # Set the Number of threads if specified
         if 'num_threads' in params and params['num_threads'] is not None:
             common_params['num_threads'] = params['num_threads']
 
@@ -867,16 +868,16 @@ class KBaseRNASeq:
         # ctx is the context object
         # return variables are: returnVal
         #BEGIN CuffdiffCall
-		
+
 	if not os.path.exists(self.__SCRATCH): os.makedirs(self.__SCRATCH)
         cuffdiff_dir = os.path.join(self.__SCRATCH,"tmp")
-        handler_util.setupWorkingDir(self.__LOGGER,cuffdiff_dir) 
+        handler_util.setupWorkingDir(self.__LOGGER,cuffdiff_dir)
 	# Set the common Params
 	common_params = {'ws_client' : Workspace(url=self.__WS_URL, token=ctx['token']),
                          'hs_client' : HandleService(url=self.__HS_URL, token=ctx['token']),
                          'user_token' : ctx['token']
                         }
-	# Set the Number of threads if specified 
+	# Set the Number of threads if specified
         if 'num_threads' in params and params['num_threads'] is not None:
             common_params['num_threads'] = params['num_threads']
 
@@ -954,7 +955,7 @@ class KBaseRNASeq:
                          'user_token'   : ctx['token']
                          #'rscripts_dir' : self.__RSCRIPTS_DIR         # QUESTION: is this the right place to pass this?
                         }
-        # Set the Number of threads if specified 
+        # Set the Number of threads if specified
         if 'num_threads' in params and params['num_threads'] is not None:
             common_params['num_threads'] = params['num_threads']
 
@@ -977,7 +978,7 @@ class KBaseRNASeq:
 
     def status(self, ctx):
         #BEGIN_STATUS
-        returnVal = {'state': "OK", 'message': "", 'version': self.VERSION, 
+        returnVal = {'state': "OK", 'message': "", 'version': self.VERSION,
                      'git_url': self.GIT_URL, 'git_commit_hash': self.GIT_COMMIT_HASH}
         #END_STATUS
         return [returnVal]

--- a/rscripts/ballgown_fpkmgenematrix.R
+++ b/rscripts/ballgown_fpkmgenematrix.R
@@ -158,7 +158,7 @@ if ( ncond > 2 )
                                    id = gene_diff_ex_tab$id,
                                    fc = NA,
                                    pval = gene_diff_ex_tab$pval,
-                                   qval = gene_diff_ex_tab$pval
+                                   qval = gene_diff_ex_tab$qval
                                  )
 
 dmesg( "about to write.table" )

--- a/test/downsized_test_metadata/ballgown_input.json
+++ b/test/downsized_test_metadata/ballgown_input.json
@@ -1,0 +1,18 @@
+{
+  "version": "1.1",
+  "method": "KBaseRNASeq.DiffExpCallforBallgown",
+  "context": null,
+  "params": [
+    {
+      "ws_id": "KBaseRNASeq_test_$user_id",
+      "expressionset_id": "downsized_AT_reads_hisat2_AlignmentSet_stringtie_ExpressionSet",
+      "output_obj_name": "downsized_AT_differential_expression_object",
+      "filtered_expr_matrix": "downsized_AT_filtered_expression_matrix",
+      "alpha_cutoff": 0.05,
+      "fold_scale_type" : "log2+1",
+      "fold_change_cutoff" : 300
+    }
+  ]
+}
+
+

--- a/test/downsized_test_metadata/build_bowtie2_index_input.json
+++ b/test/downsized_test_metadata/build_bowtie2_index_input.json
@@ -1,0 +1,16 @@
+{
+  "version": "1.1",
+  "method": "KBaseRNASeq.BuildBowtie2Index",
+  "context": null,
+  "params": [
+    {
+      "ws_id": "KBaseRNASeq_test_$user_id",
+      "output_obj_name": "at_chrom1_section_index",
+      "reference": "at_chrom1_section",
+      "type": "KBaseGenomes.Genome",
+      "source": "thale-cress",
+      "version": "1TAIR10",
+      "comment": "Arabidopsis thaliana, downsized test data created for fast unit testing. Note workspace id is tied to user_id"
+    }
+  ]
+}

--- a/test/downsized_test_metadata/create_rnaseq_sample_set_input.json
+++ b/test/downsized_test_metadata/create_rnaseq_sample_set_input.json
@@ -1,0 +1,31 @@
+{
+  "version": "1.1",
+  "method": "KBaseRNASeq.CreateRNASeqSampleSet",
+  "context": null,
+  "params": [
+    {
+      "ws_id": "KBaseRNASeq_test_$user_id",
+      "sampleset_id": "downsized_AT_reads",
+      "sampleset_desc": null,
+      "domain": "Eukaryotes",
+      "platform": "Illumina",
+      "sample_ids": [
+        "extracted_hy5_rep1.fastq",
+        "extracted_hy5_rep2.fastq",
+        "extracted_WT_rep1.fastq",
+        "extracted_WT_rep2.fastq"
+      ],
+      "condition": [
+        "hy5",
+        "hy5",
+        "WT",
+        "WT"
+      ],
+      "source": "NCBI",
+      "Library_type": "SingleEnd",
+      "publication_id": null,
+      "platform": null,
+      "string external_source_date": "not sure"
+    }
+  ]
+}

--- a/test/downsized_test_metadata/cuffdiff_input.json
+++ b/test/downsized_test_metadata/cuffdiff_input.json
@@ -1,0 +1,19 @@
+{
+  "version": "1.1",
+  "method": "KBaseRNASeq.CuffdiffCall",
+  "context": null,
+  "params": [
+    {
+      "ws_id": "KBaseRNASeq_test_$user_id",
+      "expressionset_id": "downsized_AT_reads_hisat2_AlignmentSet_cufflinks_ExpressionSet",
+      "output_obj_name": "downsized_AT_reads_cuffdiff_output",
+      "labels": null,
+      "num-threads": 2,
+      "min-alignment-count": 10,
+      "time-series": 0,
+      "multi-read-correct": 0,
+      "library-norm-method": "no scaling to FPKM",
+      "library-type": "Standard Illumina"
+    }
+  ]
+}

--- a/test/downsized_test_metadata/cufflinks_input.json
+++ b/test/downsized_test_metadata/cufflinks_input.json
@@ -1,0 +1,13 @@
+{	
+	"version":"1.1",
+	"method":"KBaseRNASeq.CufflinksCall",
+	"context": null,
+	"params":[ 	
+	{
+  	"ws_id": "KBaseRNASeq_test_$user_id",
+	"alignmentset_id" : "downsized_AT_reads_hisat2_AlignmentSet",
+    "min-intron-length" : 50,
+	"max-intron-length" : 300000,
+    "overhang-tolerance" : 8
+	}]	
+}

--- a/test/downsized_test_metadata/hisat2_input.json
+++ b/test/downsized_test_metadata/hisat2_input.json
@@ -1,0 +1,23 @@
+{
+  "version": "1.1",
+  "method": "KBaseRNASeq.Hisat2Call",
+  "context": null,
+  "params": [
+    {
+      "ws_id": "KBaseRNASeq_test_$user_id",
+      "sampleset_id": "downsized_AT_reads",
+      "genome_id": "at_chrom1_section",
+      "quality_score": "phred33",
+      "min_intron_length": 20,
+      "max_intron_length": 500000,
+      "no_spliced_alignment": 0,
+      "transcriptome_mapping_only": 0,
+      "skip": 0,
+      "trim5": 0,
+      "trim3": 0,
+      "np": 1,
+      "orientation": "fr"
+    }
+  ]
+}
+

--- a/test/downsized_test_metadata/stringtie_input.json
+++ b/test/downsized_test_metadata/stringtie_input.json
@@ -1,0 +1,23 @@
+{
+  "version": "1.1",
+  "method": "KBaseRNASeq.StringTieCall",
+  "context": null,
+  "params": [
+    {
+      "ws_id": "KBaseRNASeq_test_$user_id",
+      "alignmentset_id": "downsized_AT_reads_hisat2_AlignmentSet",
+      "min_isoform_abundance": 0.1,
+      "a_juncs": 10,
+      "min_length": 200,
+      "j_min_reads": 1,
+      "c_min_read_coverage": 2.5,
+      "gap_sep_value": 50,
+      "merge": 0,
+      "skip_reads_with_no_ref": 1,
+      "ballgown_mode" : 1
+    }
+  ]
+}
+
+
+

--- a/test/downsized_test_metadata/tophat2_input.json
+++ b/test/downsized_test_metadata/tophat2_input.json
@@ -1,0 +1,16 @@
+{	
+	"version":"1.1",
+	"method":"KBaseRNASeq.TophatCall",
+	"context": null,
+	"params":[
+	{
+	 "ws_id" : "KBaseRNASeq_test_$user_id",
+	 "sampleset_id" : "downsized_AT_reads" ,
+	 "bowtie_index" : "at_chrom1_section_index",
+	 "read_mismatches" : 2,
+	 "read_gap_length" : 2,
+         "min_intron_length" : 70,
+		"max_intron_length" : 5000000,
+	 "num_threads" : 2,
+	 "no_coverage_search" : 0 } ]
+}

--- a/test/script_test/basic_test.py
+++ b/test/script_test/basic_test.py
@@ -13,7 +13,347 @@ from subprocess import call
 import sys
 from biokbase.auth import Token
 from os import environ
+from GenomeFileUtil.GenomeFileUtilClient import GenomeFileUtil
+from ReadsUtils.ReadsUtilsClient import ReadsUtils
+import shutil
+import os
 
+
+class TestRNASeqMethodsSetupUserIndependent(unittest.TestCase):
+    '''
+    These tests set up a private workspace for the user that is running the 
+    tests. The test data is uploaded to the workspace and shock before the
+    tests are executed. This allows any user (with a valid test_token) to run 
+    the tests.
+    '''
+
+    @classmethod
+    def setUpClass(cls):
+      super(TestRNASeqMethodsSetupUserIndependent, cls).setUpClass()
+
+      print('_______BEGIN_TEST_SETUP_________')
+      token = environ.get('KB_AUTH_TOKEN', None)
+
+      if token is None:
+          sys.stderr.write(
+              "Error: Unable to run tests without authentication token!\n")
+          sys.exit(1)
+
+      token_file = open('test/script_test/token.txt', 'w')
+      token_file.write(token)
+
+      from biokbase.RNASeq.authclient import KBaseAuth as _KBaseAuth
+      from biokbase.workspace.client import Workspace as Workspace
+      try:
+          from ConfigParser import ConfigParser  # py2
+      except:
+          from configparser import ConfigParser  # py3
+
+      config_file = environ.get('KB_DEPLOYMENT_CONFIG', None)
+      cls.cfg = {}
+      config = ConfigParser()
+      config.read(config_file)
+      for nameval in config.items('KBaseRNASeq'):
+          cls.cfg[nameval[0]] = nameval[1]
+      auth_service_url = cls.cfg.get('auth-service-url',
+                                     "https://kbase.us/services/authorization/Sessions/Login")
+      ws_url = cls.cfg['ws_url']
+      auth_service_url_allow_insecure = cls.cfg[
+          'auth-service-url-allow-insecure']
+      auth_client = _KBaseAuth(auth_service_url)
+      user_id = auth_client.get_user(token)
+
+      # update workspace ids in input json
+      print('updating workspace id template in input json files...\n')
+
+      INPUT_META_DATA_DIR = "test/downsized_test_metadata/"
+      input_meta_data_files = ['create_rnaseq_sample_set_input.json',
+                               'build_bowtie2_index_input.json',
+                               'hisat2_input.json',
+                               'tophat2_input.json',
+                               'stringtie_input.json',
+                               'cufflinks_input.json',
+                               'cuffdiff_input.json',
+                               'ballgown_input.json']
+      for input_meta_data_file in input_meta_data_files:
+          with open(INPUT_META_DATA_DIR + input_meta_data_file,
+                    'r') as infile:
+              input_meta_data = json.load(infile)
+
+          # update workspace name in input.json files and write to work dir
+          ws_id_t = Template(input_meta_data['params'][0]['ws_id'])
+          cls.ws_id = ws_id_t.substitute(user_id=user_id)
+          input_meta_data['params'][0]['ws_id'] = cls.ws_id
+
+          with open('work/' + input_meta_data_file, 'w') as outfile:
+              json.dump(input_meta_data, outfile)
+
+      print('workspace_name: ' + cls.ws_id)
+
+      # create workspace that is local to the user if it does not exist
+      cls.ws = Workspace(url=ws_url, token=token, auth_svc=auth_service_url,
+                         trust_all_ssl_certificates=auth_service_url_allow_insecure)
+      try:
+          ws_info = cls.ws.get_workspace_info({'workspace': cls.ws_id})
+          print("workspace already exists: " + str(ws_info))
+      except:
+          ws_info = cls.ws.create_workspace(
+              {'workspace': cls.ws_id, 'description': 'Workspace for ' + str(
+                  input_meta_data['method'])})
+          print("Created new workspace: " + str(ws_info))
+
+      # upload genbank file
+      print('uploading input data to workspace...')
+      INPUT_DATA_DIR = "/kb/module/test/downsized_test_data/"
+      TMP_INPUT_DATA_DIR = "/kb/module/work/tmp/"
+      input_file_name = 'at_chrom1_section.gbk'
+      input_data_path = INPUT_DATA_DIR + input_file_name
+
+      print('input data path: ' + input_data_path)
+
+      with open(INPUT_META_DATA_DIR + 'build_bowtie2_index_input.json', 'r') as infile:
+          input_meta_data = json.load(infile)
+
+      # data has to be copied to tmp dir so it can be seen by
+      # GenomeFileUtil subjob running in a separate docker container
+      tmp_input_data_path = TMP_INPUT_DATA_DIR + input_file_name
+      shutil.copy(input_data_path, tmp_input_data_path)
+
+      genbankToGenomeParams = {"file": {"path": tmp_input_data_path},
+                               "genome_name": str(
+                                   input_meta_data['params'][0]['reference']),
+                               "workspace_name": cls.ws_id,
+                               "source": str(
+                                   input_meta_data['params'][0]['source']),
+                               "release": str(
+                                   input_meta_data['params'][0]['version']),
+                               "generate_ids_if_needed": True,
+                               "type": "User upload"
+                               }
+      gfu = GenomeFileUtil(os.environ['SDK_CALLBACK_URL'], token=token,
+                           auth_svc=auth_service_url)
+      save_result = gfu.genbank_to_genome(genbankToGenomeParams)
+      print('genbank_to_genome save result: ' + str(save_result))
+
+      # upload downsized single reads
+      ru = ReadsUtils(os.environ['SDK_CALLBACK_URL'], token=token)
+      input_reads = ['extracted_hy5_rep1.fastq',
+                     'extracted_hy5_rep2.fastq',
+                     'extracted_WT_rep1.fastq',
+                     'extracted_WT_rep2.fastq'
+                     ]
+      for input_file_name in input_reads:
+          input_data_path = INPUT_DATA_DIR+input_file_name
+          tmp_input_data_path = TMP_INPUT_DATA_DIR + input_file_name
+          shutil.copy(input_data_path, tmp_input_data_path)
+          print('input data path: ' + input_data_path)
+          result = ru.upload_reads({"fwd_file":tmp_input_data_path,
+                                   "sequencing_tech":"Illumina",
+                                   "wsname":cls.ws_id,
+                                   "name":input_file_name})
+          print('reads upload save result: '+str(result))
+
+      print('_______END_TEST_SETUP_________')
+
+
+    def test_a_build_bowtie2_index(self):
+          print("\n\n----------- test BuildBowtie2index ----------")
+
+          # make call
+          out =call(["./bin/run_KBaseRNASeq.sh",
+          "work/build_bowtie2_index_input.json",
+          "work/build_bowtie2_index_output.json",
+          "test/script_test/token.txt"])
+
+          print("Error code: "+str(out));
+  
+          with open('work/build_bowtie2_index_output.json') as o:
+                  output =json.load(o)
+          
+          pprint("Output: "+str(output))
+          
+          self.assertTrue(os.path.isfile('work/at_chrom1_section_index.zip'), 
+                                                'did not find output index file')
+          self.assertEqual(9078678, os.path.getsize("work/at_chrom1_section_index.zip"),
+                                                'output index file size did not match')
+    
+
+    def test_b_CreateRNASeqSampleSet(self):
+        print("\n\n----------- test CreateRNASeqSampleSet ----------")
+
+        out = call(["./bin/run_KBaseRNASeq.sh",
+                    "work/create_rnaseq_sample_set_input.json",
+                    "work/create_rnaseq_sample_set.output.json",
+                    "test/script_test/token.txt"])
+
+        # print error code of Implementation
+        print('ErrorCode: '+str(out))
+
+        with open('work/create_rnaseq_sample_set.output.json') as o:
+            output = json.load(o)
+        pprint('Output: '+str(output))
+
+        reads = self.__class__.ws.get_objects2(
+                    {'objects': [{
+                          'workspace': self.__class__.ws_id,
+                          'name': output['result'][0]['sampleset_id']}]})
+        self.assertEqual('KBaseRNASeq.RNASeqSampleSet-4.0', reads['data'][0]['info'][2],
+                                         "output sampleset object type did not match")
+
+
+    def test_c_hisat2(self):
+        print("\n\n----------- test HiSat2 ----------")
+
+        # dependency: create a reads sampleset from the reads
+        # that were uploaded in the setup
+        #self.test_CreateRNASeqSampleSet()
+
+        out =call(["./bin/run_KBaseRNASeq.sh",
+        "work/hisat2_input.json",
+        "work/hisat2_output.json",
+        "test/script_test/token.txt"])
+
+        # print error code of Implementation
+        print('ErrorCode: '+str(out))
+
+        with open('work/hisat2_output.json') as o:
+                output =json.load(o)
+        pprint('Output: '+str(output))
+
+        alignment_set = self.__class__.ws.get_objects2({'objects': [
+            {'workspace': self.__class__.ws_id,
+             'name': output['result'][0]['output']}]})
+        self.assertEqual('KBaseRNASeq.RNASeqAlignmentSet-9.0', 
+                                        alignment_set['data'][0]['info'][2],
+                                        "output alignment set object type did not match")
+
+
+    def test_d_tophat2(self):
+        print("\n\n----------- test TophatCall ----------")
+
+        # dependency: create a genome index from the genome
+        # that was uploaded in the setup
+        #self.test_build_bowtie2_index()
+
+        out =call(["run_KBaseRNASeq.sh",
+        "work/tophat2_input.json",
+        "work/tophat2_output.json",
+        "test/script_test/token.txt"])
+
+        # print error code of Implementation
+        print('ErrorCode: '+str(out))
+
+        with open('work/tophat2_output.json') as o:
+                output =json.load(o)
+        pprint('Output: '+str(output))
+
+        alignment_set = self.__class__.ws.get_objects2({'objects': [
+            {'workspace': self.__class__.ws_id,
+             'name': output['result'][0]['output']}]})
+        self.assertEqual('KBaseRNASeq.RNASeqAlignmentSet-9.0',
+                         alignment_set['data'][0]['info'][2],
+                         "output alignment set object type did not match")
+
+    def test_e_stringtie(self):
+        print("\n\n----------- test Stringtie ----------")
+
+        # dependency: create a reads alignment set
+        #elf.test_hisat2()
+
+        out = call(["run_KBaseRNASeq.sh",
+                    "work/stringtie_input.json",
+                    "work/stringtie_output.json",
+                    "test/script_test/token.txt"])
+
+        # print error code of Implementation
+        print('ErrorCode: ' + str(out))
+
+        with open('work/stringtie_output.json') as o:
+            output = json.load(o)
+        pprint('Output: ' + str(output))
+
+        expression_set = self.__class__.ws.get_objects2({'objects': [
+           {'workspace': self.__class__.ws_id,
+             'name': output['result'][0]['output']}]})
+        self.assertEqual('KBaseRNASeq.RNASeqExpressionSet-6.0',
+                         expression_set['data'][0]['info'][2],
+                         "output expression set object type did not match")
+
+    def test_f_cufflinks(self):
+        print("\n\n----------- test CufflinksCall ----------")
+
+        # dependency: create a reads alignment set
+        #self.test_hisat2()
+
+        out =call(["run_KBaseRNASeq.sh",
+        "work/cufflinks_input.json",
+        "work/cufflinks_output.json",
+        "test/script_test/token.txt"])
+
+        # print error code of Implementation
+        print('ErrorCode: ' + str(out))
+
+        with open('work/stringtie_output.json') as o:
+            output = json.load(o)
+        pprint('Output: ' + str(output))
+
+        expression_set = self.__class__.ws.get_objects2({'objects': [
+            {'workspace': self.__class__.ws_id,
+             'name': output['result'][0]['output']}]})
+        self.assertEqual('KBaseRNASeq.RNASeqExpressionSet-6.0',
+                         expression_set['data'][0]['info'][2],
+                         "output expression set object type did not match")
+
+
+    def test_g_cuffdiff(self):
+        print("\n\n----------- test CuffdiffCall ----------")
+
+        out =call(["run_KBaseRNASeq.sh",
+        "work/cuffdiff_input.json",
+        "work/cuffdiff_output.json",
+        "test/script_test/token.txt"])
+
+        # print error code of Implementation
+        print('ErrorCode: ' + str(out))
+
+        with open('work/cuffdiff_output.json') as o:
+            output = json.load(o)
+        pprint('Output: ' + str(output))
+
+        differential_expression = self.__class__.ws.get_objects2({'objects': [
+            {'workspace': self.__class__.ws_id,
+             'name': output['result'][0]['output']}]})
+        self.assertEqual('KBaseRNASeq.RNASeqDifferentialExpression-5.0',
+                         differential_expression['data'][0]['info'][2],
+                         "output differential expression object type did not match")
+    '''
+
+    def test_h_ballgown(self):
+        print("\n\n----------- test DiffExpCallforBallgown ----------")
+
+        out = call(["run_KBaseRNASeq.sh",
+                    "work/ballgown_input.json",
+                    "work/ballgown_output.json",
+                    "test/script_test/token.txt"])
+
+        # print error code of Implementation
+        print('ErrorCode: ' + str(out))
+
+        with open('work/cuffdiff_output.json') as o:
+            output = json.load(o)
+        pprint('Output: ' + str(output))
+
+        differential_expression = self.__class__.ws.get_objects2({'objects': [
+            {'workspace': self.__class__.ws_id,
+             'name': output['result'][0]['output']}]})
+        self.assertEqual('KBaseRNASeq.RNASeqDifferentialExpression-5.0',
+                         differential_expression['data'][0]['info'][2],
+                         "output differential expression object type did not match")
+
+
+
+'''
+# These tests use private workspaces that is accessible by 'kbasetest' user
 # Before all the tests, read the config file and get a user token and
 # save it to a file used by the main service script
 class TestRNASeqMethodsSetup(unittest.TestCase):
@@ -28,81 +368,6 @@ class TestRNASeqMethodsSetup(unittest.TestCase):
 
     token_file = open('test/script_test/token.txt', 'w')
     token_file.write(token)
-
-    '''
-    #######################################
-    from biokbase.RNASeq.authclient import KBaseAuth as _KBaseAuth
-    from biokbase.workspace.client import Workspace as Workspace
-    try:
-        from ConfigParser import ConfigParser  # py2
-    except:
-        from configparser import ConfigParser  # py3
-
-    config_file = environ.get('KB_DEPLOYMENT_CONFIG', None)
-    cls.cfg = {}
-    config = ConfigParser()
-    config.read(config_file)
-    for nameval in config.items('KBaseRNASeq'):
-        cls.cfg[nameval[0]] = nameval[1]
-    auth_service_url = cls.cfg.get('auth-service-url',
-                                   "https://kbase.us/services/authorization/Sessions/Login")
-    ws_url = cls.cfg['ws_url']
-    auth_service_url_allow_insecure = cls.cfg['auth-service-url-allow-insecure']
-    auth_client = _KBaseAuth(auth_service_url)
-    print('>>>>>>>>>>>>>>>>>>>>AUTH_SERVICE_URL: ' + auth_service_url)
-    print('>>>>>>>>>>>>>>>>>>>>TOKEN: ' + token)
-    user_id = auth_client.get_user(token)
-    print('>>>>>>>>>>>>>>>>>>>>USERID: '+user_id)
-
-    ws = Workspace(url=ws_url, token=token, auth_svc=auth_service_url,
-                   trust_all_ssl_certificates=auth_service_url_allow_insecure)
-
-    filename = "test/script_test/input_meta_data/hisat2_input1.json"
-    INPUT_DATA_DIR = "test/script_test/input_data"
-    with open(filename, 'r') as infile:
-        input_meta_data = json.load(infile)
-
-    # create workspace that is local to the user if it does not exist
-    workspace_name = str(input_meta_data['params'][0]['ws_id'])
-    print('workspace_name: ' + workspace_name)
-
-    try:
-        ws_info = ws.get_workspace_info({'workspace': workspace_name})
-        print("workspace already exists: " + str(ws_info))
-    except:
-        ws_info = ws.create_workspace(
-            {'workspace': workspace_name, 'description': 'Workspace for ' + str(input_meta_data['method'])})
-        print("Created new workspace: " + str(ws_info))
-
-    input_data_filename = 'test/script_test/input_data/Athaliana_PhytozomeV11_TAIR10.json'
-    print('input data filename: ' + input_data_filename)
-
-    with open(input_data_filename, 'r') as infile:
-        input_data = json.load(infile)
-
-    # upload data (no effect if data already exists in workspace)
-    print('uploading input data to workspace')
-    ws.save_objects(
-        {'workspace': workspace_name, 'objects': [{'type': "KBaseGenomes.Genome",
-                                                   'data': input_data,
-                                                   'name': 'Athaliana_PhytozomeV11_TAIR10'}]})
-
-    input_data_filename = 'test/script_test/input_data/Ath_WT_Hy5_sampleset.json'
-    print('input data filename: ' + input_data_filename)
-
-    with open(input_data_filename, 'r') as infile:
-        input_data = json.load(infile)
-
-    # upload data (no effect if data already exists in workspace)
-    print('uploading input data to workspace')
-    ws.save_objects(
-        {'workspace': workspace_name, 'objects': [{'type': 'KBaseRNASeq.RNASeqSampleSet',
-                                                   'data': input_data,
-                                                   'name': 'Ath_WT_Hy5_sampleset'}]})
-
-    print('ws objects: ' + str(ws.list_objects({'workspaces': [workspace_name]})))
-    #######################################
-    '''
 
 
 # Define all our other test cases here
@@ -141,7 +406,7 @@ class TestRNASeqMethods(TestRNASeqMethodsSetup):
 #       print("\n\n----------- test BuildBowtie2index ----------")
 #
 #       out =call(["run_KBaseRNASeq.sh",
-#       "test/script_test/new_genome_build_bowtie_input.json",
+#       "test/script_test/build_bowtie2_index_input.json",
 #       "test/script_test/new_genome_build_bowtie_output.json",
 #       "test/script_test/token.txt"])
 #
@@ -302,7 +567,11 @@ class TestRNASeqMethods(TestRNASeqMethodsSetup):
         with open('test/script_test/test_ballgown_main.output.json') as o:
                 output =json.load(o)
         pprint(output)
+'''
 
 #start the tests if run as a script
 if __name__ == '__main__':
     unittest.main()
+    
+
+

--- a/ui/narrative/methods/align_reads_using_bowtie2/display.yaml
+++ b/ui/narrative/methods/align_reads_using_bowtie2/display.yaml
@@ -1,7 +1,7 @@
 #
 # Define basic display information
 #
-name     : Align Reads using Bowtie2
+name     : Align Reads using Bowtie2 - v2.2.9
 tooltip  : |
     Align sequencing reads to long reference prokaryotic genome sequences using Bowtie2
 

--- a/ui/narrative/methods/align_reads_using_hisat2/display.yaml
+++ b/ui/narrative/methods/align_reads_using_hisat2/display.yaml
@@ -1,7 +1,7 @@
 #
 # Define basic display information
 #
-name     : Align Reads using HISAT2
+name     : Align Reads using HISAT2 - v2.0.4
 tooltip  : |
     Align sequencing reads to long reference sequences using HISAT2
 screenshots :

--- a/ui/narrative/methods/align_reads_using_tophat/display.yaml
+++ b/ui/narrative/methods/align_reads_using_tophat/display.yaml
@@ -2,7 +2,7 @@
 # Define basic display information
 #
 
-name     : Align Reads using TopHat2
+name     : Align Reads using TopHat2 - 2.1.1
 tooltip  : |
     Align sequencing reads to a reference genome using TopHat to identify exon-exon splice junctions.
 

--- a/ui/narrative/methods/assemble_transcripts_with_cufflinks/display.yaml
+++ b/ui/narrative/methods/assemble_transcripts_with_cufflinks/display.yaml
@@ -1,7 +1,7 @@
 #
 # Define basic display information
 #
-name     : Assemble Transcripts using Cufflinks
+name     : Assemble Transcripts using Cufflinks - v2.2.1
 
 tooltip  : |
     Assemble the transcripts from RNA-seq reads using Cufflinks. 

--- a/ui/narrative/methods/assemble_transcripts_with_stringtie/display.yaml
+++ b/ui/narrative/methods/assemble_transcripts_with_stringtie/display.yaml
@@ -1,7 +1,7 @@
 #
 # Define basic display information
 #
-name     : Assemble Transcripts using StringTie
+name     : Assemble Transcripts using StringTie - 1.2.3
 
 tooltip  : |
     Assemble the transcripts from RNA-seq reads using StringTie

--- a/ui/narrative/methods/build_bowtie2_index/display.yaml
+++ b/ui/narrative/methods/build_bowtie2_index/display.yaml
@@ -1,7 +1,7 @@
 #
 # Define basic display information
 #
-name     : Build Bowtie2 Index 
+name     : Build Bowtie2 Index - v2.2.9
 tooltip  : |
     Index the sequences in a reference genome using Bowtie2.
 

--- a/ui/narrative/methods/identify_differential_expression_using_ballgown/display.yaml
+++ b/ui/narrative/methods/identify_differential_expression_using_ballgown/display.yaml
@@ -1,7 +1,7 @@
 #
 # Define basic display information
 #
-name     : Create Differential Expression Matrix using Ballgown
+name     : Create Differential Expression Matrix using Ballgown - v2.0.0
 
 tooltip  : |
     Create differential expression matrix based on a given threshold cutoff


### PR DESCRIPTION
- added tests that use downsized data
- changes have been made by extension so it is easy to revert to old tests
- tests use private workspace. workspace name is tied to the username of user running the tests
- data is being uploaded each time the test is executed. i have not checked to see if data already exists in shock and has not changed
- added version number of wrapped tool in title of display.yml files